### PR TITLE
Including correct version of CDN css

### DIFF
--- a/basic-cdn-v5/public/index.html
+++ b/basic-cdn-v5/public/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <!-- Including the bootstrap css via CDN -->
-    <link 
-      rel="stylesheet" 
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" 
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" 
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+      integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
       crossorigin="anonymous"
-    >
+    />
 
     <title>React-Bootstrap CodeSandbox Starter</title>
   </head>


### PR DESCRIPTION
Changed CSS CDN link to point towards Bootstrap 5 as shown in documents, instead of old link to Bootstrap 4.

Looks like this code example was copy/pasted from v4, and only package.json got updated. This left actual CDN part to be old Bootstrap 4 CSS.